### PR TITLE
One important fix for Python 3, and some small fixes.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -232,7 +232,7 @@ Setting              Default Description
 ``returned_id``      dn      Attribute to return on authentication ('dn' or 'login')
 ``start_tls``        False   If set, initiates TLS on the connection
 ``naming_attribute`` uid     Naming attribute for directory entries
-``search_scope``     subtree Scope of LDAP searchs ('subtree' or 'onelevel')
+``search_scope``     subtree Scope of LDAP search ('subtree' or 'onelevel')
 ``restrict``                 Optional additional filter for search
 ==================== ======= =======================================================
 
@@ -284,7 +284,7 @@ Setting             Default         Description
 ``base_dn``                         Location to begin queries
 ``start_tls``       False           If set, initiates TLS on the connection
 ``attributes``                      LDAP attributes to use.
-                                    Can a comma-delitted list (e.g. uid,cn),
+                                    Can be a simple comma-delimited list (e.g. uid,cn),
                                     or a mapping list (e.g. cn=fullname,mail=email).
 ``filterstr``       (objectClass=*) A filter for the search
 ``flatten``         False           Cleans up LDAP values if they are not lists
@@ -308,6 +308,6 @@ Setting              Default Description
 ``filterstr``                A filter for the search (Default behaviour:
                              (&(objectClass=groupOfUniqueNames)(uniqueMember=%(dn)s)))
 ``name``                     The property name in the identity to use
-``search_scope``     subtree Scope of LDAP searchs ('subtree' or 'onelevel')
+``search_scope``     subtree Scope of LDAP search ('subtree' or 'onelevel')
 ``returned_id``      cn      Which attribute value of the group entry to return
 ==================== ======= =======================================================

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ CHANGELOG = open(os.path.join(HERE, 'CHANGES.rst')).read()
 
 REQUIRES = [
     'repoze.who>=2.0',
-    'python3-ldap>=0.9.0',
+    'ldap3>=0.9.0',
     'setuptools',
     'zope.interface',
 ]

--- a/src/who_ldap/__init__.py
+++ b/src/who_ldap/__init__.py
@@ -281,7 +281,7 @@ class LDAPAttributesPlugin(object):
                 conn.start_tls()
             if not conn.bind():
                 logger.error('Cannot establish connection')
-                return None
+                return
 
             dn = extract_userdata(identity)
 
@@ -295,7 +295,7 @@ class LDAPAttributesPlugin(object):
             if not status:
                 logger.error('Cannot add metadata for %s: %s'
                                 % (dn, conn.result))
-                return None
+                return
 
             result = {}
 
@@ -377,7 +377,7 @@ class LDAPGroupsPlugin(object):
                 conn.start_tls()
             if not conn.bind():
                 logger.error('Cannot establish connection')
-                return None
+                return
 
             dn = extract_userdata(identity)
 
@@ -389,7 +389,7 @@ class LDAPGroupsPlugin(object):
             if not status:
                 logger.error('Cannot add metadata for %s: %s'
                                 % (dn, conn.result))
-                return None
+                return
 
             groups = tuple(r['attributes'][self.returned_id][0]
                            for r in conn.response)

--- a/src/who_ldap/__init__.py
+++ b/src/who_ldap/__init__.py
@@ -50,11 +50,11 @@ def make_connection(url, bind_dn, bind_pass):
     return Connection(server, bind_dn, bind_pass)
 
 
-def parse_map(str):
-    if not str:
+def parse_map(mapstr):
+    if not mapstr:
         return None
     result = {}
-    for item in str.split(','):
+    for item in mapstr.split(','):
         item = item.split('=')
         if len(item) == 1:
             key = value = item[0].strip()

--- a/src/who_ldap/__init__.py
+++ b/src/who_ldap/__init__.py
@@ -285,6 +285,10 @@ class LDAPAttributesPlugin(object):
 
             dn = extract_userdata(identity)
 
+            if not dn:
+                logger.error('Malformed userdata')
+                return
+
             status = conn.search(dn,
                                  self.filterstr,
                                  SEARCH_SCOPE_BASE_OBJECT,
@@ -293,7 +297,7 @@ class LDAPAttributesPlugin(object):
                                              else self.attributes))
 
             if not status:
-                logger.error('Cannot add metadata for %s: %s'
+                logger.error('Cannot add user metadata for %s: %s'
                                 % (dn, conn.result))
                 return
 
@@ -371,7 +375,7 @@ class LDAPGroupsPlugin(object):
     # IMetadataProvider
     def add_metadata(self, environ, identity):
         logger = logging.getLogger('repoze.who')
-        
+
         with make_connection(self.url, self.bind_dn, self.bind_pass) as conn:
             if self.start_tls:
                 conn.start_tls()
@@ -381,13 +385,16 @@ class LDAPGroupsPlugin(object):
 
             dn = extract_userdata(identity)
 
+            if not dn:
+                logger.error('Malformed userdata')
+                return
+
             status = conn.search(self.base_dn,
                                  self.filterstr % {'dn': dn},
                                  self.search_scope,
                                  attributes=[self.returned_id])
-
             if not status:
-                logger.error('Cannot add metadata for %s: %s'
+                logger.error('Cannot add group metadata for %s: %s'
                                 % (dn, conn.result))
                 return
 

--- a/src/who_ldap/__init__.py
+++ b/src/who_ldap/__init__.py
@@ -68,12 +68,12 @@ def extract_userdata(identity):
     match = DNRX.search(identity.get('userdata', ''))
     if not match:
         return None
-    return b64decode(match.group('b64dn'))
+    return b64decode(match.group('b64dn')).decode('utf-8')
 
 
 def save_userdata(identity, dn):
     userdata = identity.get('userdata') or ''
-    encoded = '<dn:%s>' % b64encode(dn.encode('utf-8'))
+    encoded = '<dn:%s>' % b64encode(dn.encode('utf-8')).decode('ascii')
     identity['userdata'] = userdata + encoded
 
 

--- a/src/who_ldap/__init__.py
+++ b/src/who_ldap/__init__.py
@@ -36,7 +36,7 @@ from zope.interface import implementer
 import logging
 
 
-RE_USERDATA = re.compile('<dn:(?P<b64dn>[A-Za-z0-9+/]+=*)>')
+DNRX = re.compile('<dn:(?P<b64dn>[A-Za-z0-9+/]+=*)>')
 
 
 def make_connection(url, bind_dn, bind_pass):
@@ -65,7 +65,7 @@ def parse_map(str):
 
 
 def extract_userdata(identity):
-    match = RE_USERDATA.search(identity.get('userdata', ''))
+    match = DNRX.search(identity.get('userdata', ''))
     if not match:
         return None
     return b64decode(match.group('b64dn'))
@@ -226,7 +226,7 @@ class LDAPAttributesPlugin(object):
     Loads LDAP attributes of the authenticated user.
     """
 
-    dnrx = re.compile('<dn:(?P<b64dn>[A-Za-z0-9+/]+=*)>')
+    dnrx = DNRX
 
     def __init__(self,
                  url,
@@ -315,7 +315,7 @@ class LDAPGroupsPlugin(object):
     Add LDAP group memberships of the authenticated user to the identity.
     """
 
-    dnrx = re.compile('<dn:(?P<b64dn>[A-Za-z0-9+/]+=*)>')
+    dnrx = DNRX
 
     def __init__(self,
                  url,

--- a/src/who_ldap/__init__.py
+++ b/src/who_ldap/__init__.py
@@ -205,10 +205,10 @@ class LDAPSearchAuthenticatorPlugin(object):
             conn.search(self.base_dn, search, self.search_scope)
 
             if len(conn.response) > 1:
-                logger.error('Too many entries found for %s' % search)
+                logger.error('Too many entries found for %s', search)
                 return None
             if len(conn.response) < 1:
-                logger.warn('No entry found for %s' % search)
+                logger.warn('No entry found for %s', search)
                 return None
 
             dn = conn.response[0]['dn']
@@ -297,8 +297,8 @@ class LDAPAttributesPlugin(object):
                                              else self.attributes))
 
             if not status:
-                logger.error('Cannot add user metadata for %s: %s'
-                                % (dn, conn.result))
+                logger.error('Cannot add user metadata for %s: %s',
+                             dn, conn.result)
                 return
 
             result = {}
@@ -394,8 +394,8 @@ class LDAPGroupsPlugin(object):
                                  self.search_scope,
                                  attributes=[self.returned_id])
             if not status:
-                logger.error('Cannot add group metadata for %s: %s'
-                                % (dn, conn.result))
+                logger.error('Cannot add group metadata for %s: %s',
+                             dn, conn.result)
                 return
 
             groups = tuple(r['attributes'][self.returned_id][0]

--- a/src/who_ldap/__init__.py
+++ b/src/who_ldap/__init__.py
@@ -248,7 +248,7 @@ class LDAPAttributesPlugin(object):
                      Results won't be filtered unless you specify this.
         name -- property name in the identity to populate. If not specified,
                 will specify the identity itself.
-        attributes -- attributes to use. Can be a comma-delimted list
+        attributes -- attributes to use. Can be a comma-delimited list
                       of `name` or `name=alias` pairs (which will remap
                       attribute names to the desired alias)
         flatten -- If values contain a single item,

--- a/tests.py
+++ b/tests.py
@@ -49,7 +49,7 @@ def setup_module():
     conn = ldap3.Connection(
         server, user=BIND_DN, password=BIND_PW, auto_bind=True)
     # We must explicitly create the BASE_DN DIT components
-    # Not in python3-ldap?
+    # Not in ldap3?
     # Adding a fake user, which is used in the tests
     person_attr = {'cn': fakeuser['cn'],
                    'sn': fakeuser['sn'],


### PR DESCRIPTION
Note that Giovanni changed the name of the [python3-ldap](https://pypi.python.org/pypi/python3-ldap/) project to [ldap3](https://pypi.python.org/pypi/ldap3/), the same name of the importing package, as suggested in the [Package User Guide](https://packaging.python.org/en/latest/) by the Python Packaging Authority, to avoid confusion with the former python-ldap package.

Also note that b64de/encode returns byte strings in Python 3 which are rendered as b'...' when using string formatting. My fix was to convert the byte strings to ordinary strings.