### PR TITLE
Who ldap security fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ CHANGELOG = open(os.path.join(HERE, 'CHANGES.rst')).read()
 
 REQUIRES = [
     'repoze.who>=2.3',
-    'ldap3>=0.9.0,<2.0.0',
+    'ldap3>=2.4.1',
     'setuptools',
     'zope.interface',
 ]

--- a/src/who_ldap/__init__.py
+++ b/src/who_ldap/__init__.py
@@ -28,7 +28,7 @@ from ldap3 import (
     Connection,
     ALL_ATTRIBUTES,
     SUBTREE,
-    SEARCH_SCOPE_SINGLE_LEVEL,
+    LEVEL,
     BASE
 )
 from ldap3.utils.conv import escape_filter_chars
@@ -191,7 +191,7 @@ class LDAPSearchAuthenticatorPlugin(object):
         self.search_scope = \
             SUBTREE \
             if search_scope.lower().startswith('sub') \
-            else SEARCH_SCOPE_SINGLE_LEVEL
+            else LEVEL
         if restrict:
             self.search_pattern = u'(&%s(%s=%%s))' % (
                 restrict, naming_attribute)
@@ -381,7 +381,7 @@ class LDAPGroupsPlugin(object):
         self.search_scope = \
             SUBTREE \
             if search_scope.lower().startswith('sub') \
-            else SEARCH_SCOPE_SINGLE_LEVEL
+            else LEVEL
 
         self.name = name
         self.filterstr = filterstr or (

--- a/src/who_ldap/__init__.py
+++ b/src/who_ldap/__init__.py
@@ -27,7 +27,7 @@ from ldap3 import (
     Server,
     Connection,
     ALL_ATTRIBUTES,
-    SEARCH_SCOPE_WHOLE_SUBTREE,
+    SUBTREE,
     SEARCH_SCOPE_SINGLE_LEVEL,
     SEARCH_SCOPE_BASE_OBJECT
 )
@@ -189,7 +189,7 @@ class LDAPSearchAuthenticatorPlugin(object):
         self.ret_style = 'd' if returned_id.lower() == 'dn' else 'l'
         self.naming_pattern = u'%s=%%s,%%s' % naming_attribute
         self.search_scope = \
-            SEARCH_SCOPE_WHOLE_SUBTREE \
+            SUBTREE \
             if search_scope.lower().startswith('sub') \
             else SEARCH_SCOPE_SINGLE_LEVEL
         if restrict:
@@ -296,7 +296,7 @@ class LDAPAttributesPlugin(object):
 
             # Behave like search if filterstr is specified, otherwise use base
             if self.filterstr:
-                search_scope = SEARCH_SCOPE_WHOLE_SUBTREE
+                search_scope = SUBTREE
                 filterstr = self.filterstr.format(identity=identity)
                 # XXX This might need to be a setting?
                 base_dn = ''
@@ -379,7 +379,7 @@ class LDAPGroupsPlugin(object):
         self.bind_pass = bind_pass
         self.start_tls = bool(start_tls)
         self.search_scope = \
-            SEARCH_SCOPE_WHOLE_SUBTREE \
+            SUBTREE \
             if search_scope.lower().startswith('sub') \
             else SEARCH_SCOPE_SINGLE_LEVEL
 

--- a/src/who_ldap/__init__.py
+++ b/src/who_ldap/__init__.py
@@ -29,7 +29,7 @@ from ldap3 import (
     ALL_ATTRIBUTES,
     SUBTREE,
     SEARCH_SCOPE_SINGLE_LEVEL,
-    SEARCH_SCOPE_BASE_OBJECT
+    BASE
 )
 from ldap3.utils.conv import escape_filter_chars
 from repoze.who.interfaces import IAuthenticator, IMetadataProvider
@@ -301,7 +301,7 @@ class LDAPAttributesPlugin(object):
                 # XXX This might need to be a setting?
                 base_dn = ''
             else:
-                search_scope = SEARCH_SCOPE_BASE_OBJECT
+                search_scope = BASE
                 filterstr = '(objectClass=*)'   # ldap requires a filter string
                 base_dn = extract_userdata(identity)
                 if not base_dn:


### PR DESCRIPTION
First of all let me say that without this package I would not be able to run any of our production servers. Great job!

On 2017.11.14 ldap3 fixed a security bug on rebind that effected all lower versions. (see http://ldap3.readthedocs.io/changelog.html). The current requirements for who_ldap were between v.9 and 2.0 likely due to namespace changes (see 2.0.7 - 2016.10.27 on the changelog). 

This branch adjusts the version requirements and updated the namespace conflicts. 

There does seem to be a bit of a performance drop, but the patch covers previously know exploits in ldap3. 

This merge will require a tag update and deprecation of previous versions. 